### PR TITLE
Jinja2: keep trailing newline

### DIFF
--- a/tarjinja/jinjafilter.py
+++ b/tarjinja/jinjafilter.py
@@ -5,7 +5,7 @@ from .iface import Filter
 
 class JinjaFilter(Filter):
     def __init__(self, **kwargs):
-        self.env = Environment(**kwargs)
+        self.env = Environment(keep_trailing_newline=True, **kwargs)
         self.addfilter("brace", self.brace)
 
     def addfilter(self, name, fn):


### PR DESCRIPTION
Jinja2のデフォルト設定では、renderするとファイル末尾の改行が削除される。これは意図した動作ではなかった。